### PR TITLE
load games upon request, parse data and render game details client-side

### DIFF
--- a/Game.py
+++ b/Game.py
@@ -1,4 +1,5 @@
 import requests, os
+from datetime import datetime
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
@@ -31,24 +32,41 @@ class Game:
             self.id = app_id
             self.title = game_info['name']
             
-            if game_info['is_free']:
+            print(request_uri)
+            if game_info['is_free'] == True:
                 self.price = '0.00'
-            else:
+            elif game_info['is_free'] == False:
+
                 # format price string from cents
-                self.price = str(game_info['price_overview']['final'])[:-2] \
-                    + '.' + str(game_info['price_overview']['final'])[-2:]
+                try:
+                    self.price = str(game_info['price_overview']['final'])[:-2] \
+                        + '.' + str(game_info['price_overview']['final'])[-2:]
+                except KeyError:
+                    self.price = '0.00'
             
             # concat genres
-            if len(game_info['genres']) > 1:
-                self.genre = game_info['genres'][0]['description']
-                for genre in game_info['genres'][1:]:
-                    self.genre += ', ' + genre['description']
-            else:
-                self.genre = game_info['genres'][0]['description']
+            try:
+                if len(game_info['genres']) > 1:
+                    self.genre = game_info['genres'][0]['description']
+                    for genre in game_info['genres'][1:]:
+                        self.genre += ', ' + genre['description']
+                else:
+                    self.genre = game_info['genres'][0]['description']
+            except KeyError:
+                self.genre = ''
             
             self.description = game_info['detailed_description']
             self.image = game_info['header_image']
             self.release_date = game_info['release_date']['date']
-    
+
+    def __iter__(self):
+        yield 'app_id', self.app_id
+        yield 'title', self.title
+        yield 'price', self.price
+        yield 'description', self.description
+        yield 'image', self.image
+        yield 'release_date', self.release_date
+        yield 'genre', self.genre
+
     def __str__(self):
-        return (self.id + ': ' + self.title)
+        return str(dict(self))

--- a/SteamStats.py
+++ b/SteamStats.py
@@ -1,8 +1,7 @@
 import os, re, requests
-from flask import Flask, request, redirect, render_template, abort, session, g
+from flask import Flask, request, redirect, render_template, abort, session, g, jsonify, make_response
 from flask_openid import OpenID
 from User import User
-from datetime import datetime
 
 app = Flask(__name__)
 app.config.update({
@@ -14,17 +13,22 @@ app.config.update({
 
 oid = OpenID(app)
 
+# cache user info in memory
+user_info_store = {}
+
 @app.route('/')
 def index():
     if 'user_id' in session:
         if session['user_id'] == None:
-            return render_template('login.jinja2', user_logged_in=False)
+            return render_template('login.jinja2')
         else:
-            UserInfo = User(session['user_id'])
-            return render_template('index.jinja2', user_logged_in=True, username=UserInfo.username, avatar=UserInfo.avatar, timeCreated=UserInfo.time_created)
+            steam_id = session['user_id']
+            if steam_id not in user_info_store:
+                user_info_store[steam_id] = User(steam_id)
+            user_info = user_info_store[session['user_id']]
+            return render_template('index.jinja2', steam_id=steam_id, username=user_info.username, time_created=user_info.time_created, avatar=user_info.avatar)
     else:
-        return render_template('login.jinja2', user_logged_in=False)
-    
+        return render_template('login.jinja2')
 
 # login flow
 @app.route('/login')
@@ -37,11 +41,12 @@ def create_or_login(auth):
     _steam_re = re.compile('steamcommunity.com/openid/id/(.*?)$')
     match = _steam_re.search(auth.identity_url)
     g.user = {}
-    steamid = match.group(1)
-    g.user['id'] = steamid
-    session['user_id'] = steamid
-    return redirect('/')
-
+    steam_id = match.group(1)
+    g.user['id'] = steam_id
+    session['user_id'] = steam_id
+    if steam_id not in user_info_store:
+        user_info_store[steam_id] = User(steam_id)
+    return redirect('/profile')
 
 # pull logged in User from cookie
 @app.before_request
@@ -49,7 +54,6 @@ def before_request():
     g.user = None
     if 'user_id' in session:
         g.user = session['user_id']
-
 
 # logout
 @app.route('/logout')
@@ -66,9 +70,30 @@ def page_not_found(e):
 # Profile Page
 @app.route('/profile')
 def profile():
-    UserInfo = User(session['user_id'])
-    realDate = datetime.fromtimestamp(UserInfo.time_created)
-    return render_template('profile.jinja2', user_logged_in=True, username=UserInfo.username, avatar=UserInfo.avatar, timeCreated=realDate)
+    if 'user_id' not in session:
+        return redirect('/')
+    else:
+        steam_id = session['user_id']
+        if steam_id not in user_info_store:
+                user_info_store[steam_id] = User(steam_id)
+        user_info = user_info_store[steam_id]
+        return render_template('profile.jinja2', steam_id=steam_id, username=user_info.username, time_created=user_info.time_created, avatar=user_info.avatar)
+
+
+# Send user data by steam_id
+@app.route('/user/<steam_id>')
+def GetUserInfo(steam_id):
+    if steam_id in user_info_store:
+        user_info = user_info_store[ steam_id ]
+
+        if len(user_info.library) < 1:
+            user_info_store[steam_id].library = user_info.GetLibrary()
+
+        serialized_user = jsonify(user_info.asdict())
+        return make_response(serialized_user, 200)
+
+    else:
+        return abort(404)
 
 if __name__ == '__main__':
     app.run()

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -16,3 +16,27 @@
 .footer-btn {
     margin-top: 12px;
 }
+
+.table-img {
+    max-width: 33%;
+    height: auto;
+}
+
+#loader {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    -webkit-animation:spin 2s linear infinite;
+    -moz-animation:spin 2s linear infinite;
+    animation:spin 2s linear infinite;
+}
+
+#loader .fa-spinner {
+    width: 32px;
+    height: 32px;
+    color: #007bff;
+}
+
+@-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
+@-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
+@keyframes spin { 100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); } }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,0 +1,56 @@
+$(document).ready(() => {
+    $('#loader').hide();
+});
+
+function loadGameDetails() {
+    $('#loader').show();
+    let gameLibrary = {};
+    if (localStorage.userInfo) {
+        let userInfo = JSON.parse(localStorage.userInfo);
+        gameLibrary = userInfo.library;
+        buildTable(gameLibrary);
+    } else {
+        $('#loader').show();
+        let profileId = $("meta[name=locale]").attr("content");
+        fetch('/user/76561198061533639')
+        .then(response => {
+            return response.json();
+        })
+        .then(body => {
+            localStorage.userInfo = JSON.stringify(body);
+            buildTable(body.library);
+        });
+    }
+}
+
+function buildTable(games) {
+    for (var app_id in games) {
+        let thisGame = games[app_id].game;
+
+        let newRow = $('<tr></tr>');
+        let imgCell = $('<td></td>'); imgCell
+            .append( $('<img></img>')
+            .attr('src', thisGame.image)
+            .addClass('table-img'));
+
+        let titleCell = $('<td></td>').text(thisGame.title);
+        let genreCell = $('<td></td>').text(thisGame.genre);
+
+        let price = '';
+        if (thisGame.price != '0.00') {
+            price = '$' + thisGame.price;
+        } else {
+            price = 'Free';
+        }
+        
+        let priceCell = $('<td></td>').text(price);
+
+        let playedtime = ((games[app_id].played_time / 60).toFixed(2) + ' hours');
+        let playtimeCell = $('<td></td>').text(playedtime);
+        
+        newRow.append(imgCell).append(titleCell).append(genreCell).append(priceCell).append(playtimeCell);
+
+        $('#games table').append(newRow);
+    };
+    $('#loader').hide();
+}

--- a/templates/header.jinja2
+++ b/templates/header.jinja2
@@ -24,20 +24,22 @@
                     <i class="fa fa-search"></i>
                 </button>
             </form>
+
+            {% if steam_id %}
             <div class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     {{ username }}
                     <img src= {{ avatar }} class="img-thumbnail" width = 32, height = 32>
                 </a>
-
+                
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                     <a class="dropdown-item" href="/profile">Profile</a>
                     <a class="dropdown-item" href="/settings">Settings</a>
                     <div class="dropdown-divider"></div>
                     <a class="dropdown-item" href="/logout">Logout</a>
                 </div>
-                
             </div>
+            {% endif %}
         </div>
     </nav>
 

--- a/templates/layout.jinja2
+++ b/templates/layout.jinja2
@@ -7,10 +7,19 @@
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
     <link href="/static/css/style.css" rel="stylesheet" type="text/css" />
 
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T" crossorigin="anonymous"></script>
+    <script defer src="https://use.fontawesome.com/releases/v5.0.13/js/all.js" integrity="sha384-xymdQtn1n3lH2wcu0qhcdaOpQwyoarkgLVxC/wZ5q7h9gHtxICrpcaSUfygqZGOe" crossorigin="anonymous"></script>
+    <script src="/static/js/script.js"></script>
+
     <title>{% block title %}{% endblock %} SteamStats</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="SteamStats">
     <meta name="keywords" content="Steam, SteamStats, PC game, PC gaming, steam library">
+    {% if steam_id %}
+    <meta name="profile" content="{{steam_id}}">
+    {% endif %}
     {% endblock %}
 </head>
 
@@ -30,10 +39,8 @@
         {% include 'footer.jinja2' %}
     </footer>
 
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T" crossorigin="anonymous"></script>
-    <script defer src="https://use.fontawesome.com/releases/v5.0.13/js/all.js" integrity="sha384-xymdQtn1n3lH2wcu0qhcdaOpQwyoarkgLVxC/wZ5q7h9gHtxICrpcaSUfygqZGOe" crossorigin="anonymous"></script>
-    <script src="/static/js/script.js"></script>
+    <div id="loader">
+        <i class="fa fa-spinner"></i>
+    </div>
 </body>
 </html>

--- a/templates/profile.jinja2
+++ b/templates/profile.jinja2
@@ -3,10 +3,24 @@
 {% block content %}
 
 <div style="text-align: center;">
-    <h1><img src= {{ avatar }} class="img-fluid" alt="Responsive image"></img></h1>
+    <h1><img src= "{{ avatar }}" class="img-fluid" alt="Responsive image"></img></h1>
     <h1>{{ username }}'s Profile</h1>
-    <h4>Your profile was created on {{ timeCreated }}.</h4>
+    <h4>Your profile was created on {{ time_created }}.</h4>
 </div>
 
+<div id="games">
+    <table class="table table-hover">
+        <thead>
+            <th scope="col"></th>
+            <th scope="col">Game</th>
+            <th scope="col">Genre</th>
+            <th scope="col">Price</th>
+            <th scope="col">Time Played</th>
+        </thead>
 
+        <tbody id="gamesinfo">
+        </tbody>
+    </table>
+</div>
+<script>loadGameDetails()</script>
 {% endblock %}


### PR DESCRIPTION
Fill in the following info below for your PR:

Is this for an issue? If so, which? #13, #14, #20, #31, #32 
What does this change do?

- When User class is initialized, don't fetch games
- API endpoint for user steam data (`/user/<steam_id>`)
- Game data is fetched upon request to above endpoint if not already cached
- Game table view rendered client-side

Be sure to request a reviewer to the right to get your change merged.
