### PR TITLE
Search results, friend profile endpoint

### DIFF
--- a/SteamStats.py
+++ b/SteamStats.py
@@ -133,6 +133,7 @@ def results():
 
     # get search params
     keyword = request.args.get('q')
+    keyword = keyword.lower()
     results = []
 
     for (steam_id, user) in user_info_store.items():

--- a/SteamStats.py
+++ b/SteamStats.py
@@ -5,15 +5,6 @@ from threading import Thread
 
 from User import User
 
-# flag for GetLibrary thread
-GET_LIB_WORKING = False
-
-# cache user info in memory
-user_info_store = {}
-
-# cache game info in memory
-user_info_store = {}
-
 # init app
 app = Flask(__name__)
 app.config.update({
@@ -26,19 +17,49 @@ app.config.update({
 oid = OpenID(app)
 
 
+### data caches
+# cache user info in memory
+user_info_store = {}
+
+# cache game info in memory
+game_info_store = {}
+
+with app.app_context():
+    ### template responses
+    # pending library
+    RESP_LIBRARY_PENDING = make_response(jsonify({'message':'Collecting game library...'}), 202)
+
+    # user not found
+    RESP_USER_NOT_FOUND = make_response(jsonify({'error':'User not found'}), 404)
+
+### flags
+# GetLibrary thread
+GET_LIB_WORKING = False
+
+# LoadGamesInStore thread
+LOAD_GAMES_WORKING = False
+
+
+### ROUTES below
+# -----------------------
+
 @app.route('/')
 def index():
     if 'user_id' in session:
         if session['user_id'] == None:
             return render_template('login.jinja2')
+
         else:
             steam_id = session['user_id']
             if steam_id not in user_info_store:
                 user_info_store[steam_id] = User(steam_id)
+
             user_info = user_info_store[session['user_id']]
             return render_template('index.jinja2', steam_id=steam_id, username=user_info.username, time_created=user_info.time_created, avatar=user_info.avatar)
+
     else:
         return render_template('login.jinja2')
+
 
 # login flow
 @app.route('/login')
@@ -54,9 +75,12 @@ def create_or_login(auth):
     steam_id = match.group(1)
     g.user['id'] = steam_id
     session['user_id'] = steam_id
+
     if steam_id not in user_info_store:
         user_info_store[steam_id] = User(steam_id)
+
     return redirect('/profile')
+
 
 # pull logged in User from cookie
 @app.before_request
@@ -64,6 +88,7 @@ def before_request():
     g.user = None
     if 'user_id' in session:
         g.user = session['user_id']
+
 
 # logout
 @app.route('/logout')
@@ -77,48 +102,71 @@ def logout():
 def page_not_found(e):
     return render_template('404.jinja2'), 404
 
+
 # Profile Page
 @app.route('/profile')
 def profile():
     if 'user_id' not in session:
         return redirect('/')
+
     else:
         steam_id = session['user_id']
         if steam_id not in user_info_store:
             user_info_store[steam_id] = User(steam_id)
+
         user_info = user_info_store[steam_id]
         return render_template('profile.jinja2', steam_id=steam_id, username=user_info.username, time_created=user_info.time_created, avatar=user_info.avatar)
 
-# Results Page
+# Profile Page (for specific user)
+@app.route('/profile/<steam_id>')
+def profileById(steam_id):
+    if steam_id not in user_info_store:
+        user_info_store[steam_id] = User(steam_id)
+    
+    user_info = user_info_store[steam_id]
+    return render_template('profile.jinja2', steam_id=steam_id, username=user_info.username, time_created=user_info.time_created, avatar=user_info.avatar)
+
+
+# Search results Page
 @app.route('/results')
 def results():
-    return render_template('results.jinja2')
+
+    # get search params
+    keyword = request.args.get('q')
+    results = []
+
+    for (steam_id, user) in user_info_store.items():
+        if keyword in user.username:
+            results.append({'url': '/profile/' + steam_id, 'text': user.username})
+    
+    for (app_id, game) in game_info_store.items():
+        if keyword in game.title or keyword in game.description or keyword in game.genre:
+            results.append({'url': 'https://store.steampowered.com/app/' + app_id, 'text': game.title})
+
+    print('search results:', results)
+    return render_template('results.jinja2', results=results)
+
 
 # Friends Page
 @app.route('/friends')
 def friends():
     return render_template('friends.jinja2')
   
+
 # Get user data by steam_id
 @app.route('/user/<steam_id>')
 def GetUserInfo(steam_id):
     global GET_LIB_WORKING
-
-    def GetGames(user):
-        global GET_LIB_WORKING
-
-        user.GetLibrary()
-        GET_LIB_WORKING = False
 
     if steam_id in user_info_store:
         if (not GET_LIB_WORKING) and len(user_info_store[steam_id].library) < 1:
             thread = Thread(target=GetGames, args=[user_info_store[steam_id]])
             thread.start()
             GET_LIB_WORKING = True
-            return make_response('Collecting game library...', 202)
+            return RESP_LIBRARY_PENDING
 
         elif GET_LIB_WORKING:
-            return make_response('Collecting game library...', 202)
+             return RESP_LIBRARY_PENDING
             
         elif not GET_LIB_WORKING:
             serialized_user = jsonify(user_info_store[steam_id].asdict())
@@ -128,18 +176,62 @@ def GetUserInfo(steam_id):
             return make_response('Error: There was a problem completing your request. Check your query and try again.', 400)
         
     else:
-        return make_response(jsonify({'error': 'User not found'}), 404)
+        return RESP_USER_NOT_FOUND
 
+
+# Get # of games in user's library
+#   (specifically: total games vs. loaded games.
+#   This endpoint is used to poll load progress)
 @app.route('/user/<steam_id>/count')
 def GetUserGameCount(steam_id):
     if steam_id in user_info_store:
         result = {'total': user_info_store[steam_id].gamecount, 'loaded': len(user_info_store[steam_id].library)}
         if result['total'] > result['loaded']:
             return make_response(jsonify(result), 202)
+
         else:
             return make_response(jsonify(result), 200)
-    else:
-        return make_response(jsonify({'error': 'User not found'}), 404)
 
+    else:
+        return RESP_USER_NOT_FOUND
+
+
+# Get user library directly
+@app.route('/user/<steam_id>/games')
+def GetUserGameLibrary(steam_id):
+    if steam_id in user_info_store:
+        if not GET_LIB_WORKING:
+            resp = jsonify(user_info_store[steam_id].library)
+            return make_response(resp, 200)
+
+        else:
+             return RESP_LIBRARY_PENDING
+
+    else:
+        return RESP_USER_NOT_FOUND
+
+
+### HELPER functions below
+# ------------------------
+
+def GetGames(user):
+    global GET_LIB_WORKING
+
+    user.GetLibrary()
+    GET_LIB_WORKING = False
+
+    if not LOAD_GAMES_WORKING:
+        thread = Thread(target=LoadGamesInStore, args=[user])
+        thread.start()
+
+
+# Load previously fetched games into memory
+def LoadGamesInStore(user):
+    for (app_id, game) in user.library.items():
+        if game['game'].id not in game_info_store:
+            game_info_store[app_id] = game['game']
+
+
+# Run the thing
 if __name__ == '__main__':
     app.run()

--- a/User.py
+++ b/User.py
@@ -41,7 +41,6 @@ class User:
 
         self.gamecount = len(library_array)
 
-        library = {}
         for game in library_array:
             steam_id = str(game['appid'])
             self.library[steam_id] = {'game': Game(steam_id), 'played_time': game['playtime_forever']}

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -8,8 +8,8 @@ function loadGameDetails() {
     profileId =  $("meta[name=profile]").attr("content");
     $('.progress').show();
     let gameLibrary = {};
-    if (localStorage.userInfo) {
-        let userInfo = JSON.parse(localStorage.userInfo);
+    if (localStorage[profileId]) {
+        let userInfo = JSON.parse(localStorage[profileId]);
         gameLibrary = userInfo.library;
         buildTable(gameLibrary);
     } else {
@@ -19,7 +19,7 @@ function loadGameDetails() {
                 checkLoadProgress();
             } else if (response.status == 200) {
                 response.json().then((body) => {
-                    localStorage.userInfo = JSON.stringify(body);
+                    localStorage[profileId] = JSON.stringify(body);
                     buildTable(body.library);
                 });
             }

--- a/templates/header.jinja2
+++ b/templates/header.jinja2
@@ -19,7 +19,7 @@
                 </li>
             </ul>
             <form action='/results' class="form-inline my-2 my-lg-0" method='GET'>
-                <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search">
+                <input class="form-control mr-sm-2" name="q" id="q" type="search" placeholder="Search" aria-label="Search">
                 <button class="btn btn-outline-secondary my-2 my-sm-0" type="submit">
                     <i class="fa fa-search"></i>
                 </button>

--- a/templates/results.jinja2
+++ b/templates/results.jinja2
@@ -6,4 +6,12 @@
     <h1>Results:</h1>
 </div>
 
+{% for result in results %}
+<div class="search-result">
+    <a href="{{result.url}}">{{result.text}}</a>
+</div>
+{% endfor %}
+
+
+
 {% endblock %}


### PR DESCRIPTION
This is a combined PR for issues #56, #54, and #23.

- Can now view other users' profiles by visiting `/profile/<steam_id>`
- Can search in the navbar (uses keyword to look for games & friends)
- On the backend, a `game_info_store` now caches games that have been previously fetched for faster processing (reverse lookup from `User.library`)