### PR TITLE
Render game list server-side

### DIFF
--- a/SteamStats.py
+++ b/SteamStats.py
@@ -128,6 +128,7 @@ def profile():
 
         user_info = user_info_store[steam_id]
         user_library = buildLibraryForUser(steam_id)
+
         return render_template(
             'profile.jinja2',
             steam_id=steam_id,
@@ -144,12 +145,15 @@ def profileById(steam_id):
         user_info_store[steam_id] = User(steam_id)
 
     user_info = user_info_store[steam_id]
+    user_library = buildLibraryForUser(steam_id)
+
     return render_template(
         'profile.jinja2',
         steam_id=steam_id,
         username=user_info.username,
         time_created=user_info.time_created,
-        avatar=user_info.avatar)
+        avatar=user_info.avatar,
+        game_library=user_library)
 
 
 # Search results Page
@@ -300,21 +304,7 @@ def buildLibraryForUser(steam_id):
 def LoadMissingGames(missing_apps, steam_id):
     print('Data missing for {} apps, fetching...'.format(len(missing_apps)))
     for app_id in missing_apps:
-        game_data = GetGameInfo(app_id)
-        if game_data is not None:
-            played_time = ''
-            for game in user_info_store[steam_id].library:
-                if game['app_id'] == app_id:
-                    played_time = game['played_time']
-                    break
-
-            results.append({
-                'app_id': app_id,
-                'played_time': played_time,
-                'game_data': dict(game_data)
-            })
-        else:
-            continue
+        GetGameInfo(app_id)
 
 
 # Check game data against DB by app_id, add if missing

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,40 +1,39 @@
 #steamlogo {
-    fill: white;
+  fill: white;
 }
 
 .container {
-    margin-top: 90px;
-    margin-bottom: 60px;
+  margin-top: 90px;
+  margin-bottom: 60px;
 }
 
 #games {
-    margin-bottom: 70px;
+  margin-bottom: 70px;
 }
 
 .footer {
-    position: fixed;
-    bottom: 0;
-    height: 60px;
-    width: 100%;
-    margin-left: 0;
-    margin-right: 0;
+  position: fixed;
+  bottom: 0;
+  height: 60px;
+  width: 100%;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .footer-text {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
 .footer-btn {
-    margin-top: 12px;
+  margin-top: 12px;
 }
 
 .table-img {
-    max-width: 33%;
-    height: auto;
+  max-width: 80%;
+  height: auto;
 }
 
-
 .progress {
-    width: 33%;
-    margin: 0 auto;
+  width: 33%;
+  margin: 0 auto;
 }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,59 +1,31 @@
-var profileId = '';
-
 $(document).ready(() => {
-    loadGameDetails();
-});
 
-function loadGameDetails() {
-    profileId = $("meta[name=profile]").attr("content");
-    $('.progress').show();
-    fetch('/user/' + profileId + '/games').then(response => {
-        if (response.status == 200) {
-            response
-                .json()
-                .then((games) => {
-                    //console.log(games);
-                    buildTable(games);
-                });
-        }
-    });
-    $('.progress').hide();
-}
-
-function buildTable(games) {
-    console.log('building table...');
-    games.forEach(game => {
-        console.log('Building row for ' + game);
-
-        let app_id = game.app_id
-        let game_data = game.game_data
-        let newRow = $('<tr id="' + app_id + '"></tr>');
-        let imgCell = $('<td></td>');
-        imgCell.append($('<a></a>').attr('href', 'http://store.steampowered.com/app/' + app_id).append($('<img></img>').attr('src', game_data.image).addClass('table-img')));
-
-        let titleCell = $('<td></td>').text(game_data.title);
-        let genreCell = $('<td></td>').text(game_data.genre);
-
-        let price = '';
-        if (game_data.price != '0.00') {
-            price = '$' + game_data.price;
+    // format playtime values
+    $('td.playtime').each((idx) => {
+        let target = $($('td.playtime')[idx])
+        let gamePlaytime = parseInt(target.text());
+        let result = '';
+        if (gamePlaytime >= 60) {
+            result = (((gamePlaytime / 60).toFixed(1)).toString() + ' hours');
+        } else if (gamePlaytime > 0) {
+            result = (gamePlaytime.toString()) + ' mins';
         } else {
-            price = 'Free';
+            result = 'Never played'
         }
-
-        let priceCell = $('<td></td>').text(price);
-
-        let playedtime = ((game.played_time / 60).toFixed(2) + ' hours');
-        let playtimeCell = $('<td></td>').text(playedtime);
-
-        newRow
-            .append(imgCell)
-            .append(titleCell)
-            .append(genreCell)
-            .append(priceCell)
-            .append(playtimeCell);
-
-        $('#games table').append(newRow);
+        target.text(result)
     });
-    $('.progress').hide();
-}
+
+    // format price values
+    $('td.price').each((idx) => {
+        let target = $($('td.price')[idx])
+        let gamePrice = target.text();
+        let result = target.text();
+        if (gamePrice == '$0.00') {
+            result = 'Free'
+        }
+        target.text(result)
+    });
+
+    // data table for sorting/pagination
+    $('#games table').DataTable();
+});

--- a/templates/games.jinja2
+++ b/templates/games.jinja2
@@ -1,0 +1,31 @@
+{% block games %}
+
+    <div id="games">
+        <table class="table table-hover">
+            <thead>
+                <th scope="col"></th>
+                <th scope="col">Game</th>
+                <th scope="col">Genre</th>
+                <th scope="col">Price</th>
+                <th scope="col">Time Played</th>
+            </thead>
+
+            <tbody id="gamesinfo">
+                {% for game in game_library %}
+                    <tr id="4000">
+                        <td>
+                            <a href="http://store.steampowered.com/app/{{game.app_id}}">
+                                <img src="{{game.game_data.image}}" class="table-img">
+                            </a>
+                        </td>
+                        <td class="title">{{game.game_data.title}}</td>
+                        <td class="genre">{{game.game_data.genre}}</td>
+                        <td class="price" data-order="{{game.game_data.price}}">${{game.game_data.price}}</td>
+                        <td class="playtime" data-order="{{game.played_time}}">{{game.played_time}}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+{% endblock %}

--- a/templates/layout.jinja2
+++ b/templates/layout.jinja2
@@ -6,11 +6,13 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
     <link href="/static/css/style.css" rel="stylesheet" type="text/css" />
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.10.18/datatables.min.css"/>
 
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T" crossorigin="anonymous"></script>
     <script defer src="https://use.fontawesome.com/releases/v5.0.13/js/all.js" integrity="sha384-xymdQtn1n3lH2wcu0qhcdaOpQwyoarkgLVxC/wZ5q7h9gHtxICrpcaSUfygqZGOe" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.18/datatables.min.js"></script>
     <script src="/static/js/script.js"></script>
 
     <title>{% block title %}{% endblock %} SteamStats</title>

--- a/templates/profile.jinja2
+++ b/templates/profile.jinja2
@@ -8,19 +8,6 @@
     <h4>Your profile was created on {{ time_created }}.</h4>
 </div>
 
-<div id="games">
-    <table class="table table-hover">
-        <thead>
-            <th scope="col"></th>
-            <th scope="col">Game</th>
-            <th scope="col">Genre</th>
-            <th scope="col">Price</th>
-            <th scope="col">Time Played</th>
-        </thead>
+{% include 'games.jinja2' with context %}
 
-        <tbody id="gamesinfo">
-        </tbody>
-    </table>
-</div>
-<script>loadGameDetails()</script>
 {% endblock %}


### PR DESCRIPTION
Fill in the following info below for your PR:

- Is this for an issue? If so, which?
  - Fixes #62 
  - Fixes #64 
  - Fixes #65 
  - Fixes #66 
  - Fixes #68 

- What does this change do?
  - Games now load on the server side (much faster). 
  - External user games load (`/profile/<steam_id>`)
  - Playtime/price data is formatted client-side. 
  - DataTable bootstrap plugin added for sorting by columns in the game table.

Be sure to request a reviewer to the right to get your change merged.
